### PR TITLE
update gitignore for vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,24 @@
+# Local environment
+.DS_Store
+Thumbs.db
+
+# Vagrant
+.vagrant/
+
+# VS Code
+.vscode/
+
+# Test reports
+unittests.xml
+
+# database files
+db/*
+!db/.keep
+
+# SonarQube Reports
+.scannerwork/
+.sonarlint/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
added the following to the gitignore to keep unneeded files from being tracked by the repo:

# Local environment
.DS_Store
Thumbs.db

# Vagrant
.vagrant/

# VS Code
.vscode/

# Test reports
unittests.xml

# database files
db/*
!db/.keep

# SonarQube Reports
.scannerwork/
.sonarlint/

