### PR TITLE
add rednose to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ flake8==3.7.9
 # Testing
 factory-boy==2.12.0
 nose==1.3.7
+rednose==1.3.0
 pinocchio==0.4.2
 httpie==2.3.0
 


### PR DESCRIPTION
nosetests was erroring without rednose in the requirements.txt file.
added rednose to the file.