### PR TITLE
issue #72 GET `/shopcarts/123` returns HTML 500 error

### DIFF
--- a/service/error_handlers.py
+++ b/service/error_handlers.py
@@ -68,7 +68,7 @@ def method_not_supported(error):
 
 @app.errorhandler(status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
 def mediatype_not_supported(error):
-    """Handles unsuppoted media requests with 415_UNSUPPORTED_MEDIA_TYPE"""
+    """Handles unsupported media requests with 415_UNSUPPORTED_MEDIA_TYPE"""
     message = str(error)
     app.logger.warning(message)
     return (

--- a/service/models.py
+++ b/service/models.py
@@ -144,7 +144,7 @@ class Shopcart(db.Model):
                 shopcart_id (int): the shopcart id of the Shopcart you want to match
         """
         logger.info("Processing lookup for shopcart_id %d ...", shopcart_id)
-        return cls.query.filter(cls.shopcart_id == shopcart_id)
+        return cls.query.filter(cls.shopcart_id == shopcart_id).all()
 
     # @classmethod
     # def find_by_name(cls, name):

--- a/service/routes.py
+++ b/service/routes.py
@@ -95,7 +95,7 @@ def list_one_shopcart_item(shopcart_id):
     else:
         shopcarts = Shopcart.find_by_shopcart_id(shopcart_id)
 
-    if not shopcarts or len(shopcarts) < 1:
+    if not shopcarts:
             app.logger.info("Returning 0 items")
             message = "no items found"
             return make_response(

--- a/service/routes.py
+++ b/service/routes.py
@@ -87,19 +87,20 @@ def list_one_shopcart_item(shopcart_id):
     """ Query an item from a customer's Shopcart """
     app.logger.info("Request an item from the Shopcart")
 
-    product_param = int(request.args.get("product-id"))
+    product_param = request.args.get("product-id")
     product_id = int(request.args.get("product-id")) if product_param else None
+
     if product_id:
         shopcarts = Shopcart.find(shopcart_id, product_id)
     else:
         shopcarts = Shopcart.find_by_shopcart_id(shopcart_id)
 
-    if not shopcarts:
+    if not shopcarts or len(shopcarts) < 1:
             app.logger.info("Returning 0 items")
             message = "no items found"
             return make_response(
                 jsonify(message),
-                status.HTTP_200_OK
+                status.HTTP_404_NOT_FOUND
             )
     if shopcart_id and product_id:
         results = [shopcarts.serialize()]


### PR DESCRIPTION
1. Checks if query parameter exists before entering it in INT()
2. Runs .all() on query for all items without product-id to return array instead of BaseQuery
3. Fixed typo in comment