### PR TITLE
refactor parameters to list items, add test cases for error handlers

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -26,6 +26,7 @@ from service.models import Shopcart, DataValidationError
 # Import Flask application
 from . import app
 
+
 ######################################################################
 # GET INDEX
 ######################################################################
@@ -42,6 +43,7 @@ def index():
         status.HTTP_200_OK,
     )
 
+
 #####################################################################
 # LIST ALL ITEMS
 #####################################################################
@@ -51,8 +53,8 @@ def list_items():
     app.logger.info("Request for Shopcarts list")
     shopcarts = []
     results = []
-    shopcart_param = request.args.get("shopcart-id")
-    product_param = request.args.get("product-id")
+    shopcart_param = request.args.get("shopcart_id")
+    product_param = request.args.get("product_id")
     shopcart_id = (int(shopcart_param)) if shopcart_param else None
     product_id = (int(product_param)) if product_param else None
     if shopcart_id and product_id:
@@ -69,7 +71,7 @@ def list_items():
             message = []
             return make_response(
                 jsonify(message),
-                status.HTTP_200_OK
+                status.HTTP_404_NOT_FOUND
             )
     if shopcart_id and product_id:
         results = [shopcarts.serialize()]
@@ -80,6 +82,7 @@ def list_items():
         jsonify(results),
         status.HTTP_200_OK
     )
+
 
 ######################################################################
 # READ ITEMS FROM A CUSTOMER'S SHOPCART
@@ -105,6 +108,7 @@ def list_items_in_shopcart(shopcart_id):
         jsonify(results),
         status.HTTP_200_OK
     )
+
 
 ######################################################################
 # UPDATE AN EXISTING ITEM
@@ -137,6 +141,7 @@ def update_item(shopcart_id,product_id):
         shopcart.deserialize(request_dict)
         shopcart.update()
         return make_response(jsonify(shopcart.serialize()), status.HTTP_200_OK)
+
 
 ######################################################################
 # DELETE A ITEM

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -165,7 +165,7 @@ class TestYourResourceServer(TestCase):
         item1 = self._create_shopcart_with_item(1234, 100)
         item2 = self._create_shopcart_with_item(1234, 101)
         item3 = self._create_shopcart_with_item(1234, 102)
-        resp = self.app.get("/shopcarts?shopcart-id={}".format(item1.shopcart_id))
+        resp = self.app.get("/shopcarts?shopcart_id={}".format(item1.shopcart_id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         items = resp.get_json()
         self.assertEqual(items[0]["shopcart_id"], item1.shopcart_id)
@@ -176,7 +176,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(items[2]["product_id"], item3.product_id)
         """ Test list items shopcart_id and product_id"""
         item4 = self._create_shopcart_with_item(1234, 103)
-        resp = self.app.get("/shopcarts?shopcart-id={}&product-id={}".format(item4.shopcart_id, item4.product_id))
+        resp = self.app.get("/shopcarts?shopcart_id={}&product_id={}".format(item4.shopcart_id, item4.product_id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         items = resp.get_json()
         self.assertEqual(items[0]["shopcart_id"], item4.shopcart_id)
@@ -188,15 +188,15 @@ class TestYourResourceServer(TestCase):
         item1 = self._create_shopcart_with_item(1234, 100)
         item2 = self._create_shopcart_with_item(1234, 101)
         item3 = self._create_shopcart_with_item(1234, 102)
-        resp = self.app.get("/shopcarts?shopcart-id={}&product-id={}".format(item1.shopcart_id, item1.product_id))
+        resp = self.app.get("/shopcarts?shopcart_id={}&product_id={}".format(item1.shopcart_id, item1.product_id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         item = resp.get_json()
         self.assertEqual(item[0]["product_id"], item1.product_id)
-        resp = self.app.get("/shopcarts?shopcart-id={}&product-id={}".format(item2.shopcart_id, item2.product_id))
+        resp = self.app.get("/shopcarts?shopcart_id={}&product_id={}".format(item2.shopcart_id, item2.product_id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         item = resp.get_json()
         self.assertEqual(item[0]["product_id"], item2.product_id)
-        resp = self.app.get("/shopcarts?shopcart-id={}&product-id={}".format(item3.shopcart_id, item3.product_id))
+        resp = self.app.get("/shopcarts?shopcart_id={}&product_id={}".format(item3.shopcart_id, item3.product_id))
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         item = resp.get_json()
         self.assertEqual(item[0]["product_id"], item3.product_id)
@@ -273,7 +273,7 @@ class TestYourResourceServer(TestCase):
         item2 = self._create_shopcart_with_item(1234, 101)
         item3 = self._create_shopcart_with_item(1234, 102)
 
-        resp = self.app.get("/shopcarts?shopcart_id=123")
+        resp = self.app.get("/shopcarts?shopcart_id=1234")
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertEqual(len(resp.get_json()), 3)
 
@@ -281,9 +281,9 @@ class TestYourResourceServer(TestCase):
 
         self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
 
-        resp = self.app.get("/shopcarts?shopcart_id=123")
+        resp = self.app.get("/shopcarts?shopcart_id=1234")
 
-        self.assertEqual(resp.get_json(), "no items found")
+        self.assertEqual(resp.get_json(), [])
 
 
     def test_read_items(self):
@@ -300,3 +300,58 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(items[2]["product_id"], item3.product_id)
     
 
+    def test_read_404(self):
+        """ Test read not found """
+        shopcart_id1 = 1231
+        shopcart_id2 = 1232
+        shopcart_id3 = 1233
+        shopcart_id1234 = 1234
+        product_id = 100
+        item1 = self._create_shopcart_with_item(shopcart_id1, product_id)
+        item2 = self._create_shopcart_with_item(shopcart_id2, product_id)
+        item3 = self._create_shopcart_with_item(shopcart_id3, product_id)
+        resp = self.app.get("/shopcarts/{}".format(shopcart_id1234))
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+
+    def test_query_items_with_product_id(self):
+        """ Test list shopcarts with product id """
+        shopcart_id1 = 1231
+        shopcart_id2 = 1232
+        shopcart_id3 = 1233
+        product_id = 100
+        item1 = self._create_shopcart_with_item(shopcart_id1, product_id)
+        item2 = self._create_shopcart_with_item(shopcart_id2, product_id)
+        item3 = self._create_shopcart_with_item(shopcart_id3, product_id)
+        resp = self.app.get("/shopcarts?product_id={}".format(product_id))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        items = resp.get_json()
+        self.assertEqual(items[0]["product_id"], item1.product_id)
+        self.assertEqual(items[1]["product_id"], item2.product_id)
+        self.assertEqual(items[2]["product_id"], item3.product_id)
+
+
+    # def test_bad_request(self):
+    #     """ Test error handlers bad request """
+    #     product_id = 1000
+    #     resp = self.app.get("/shopcarts?product-id{}".format(product_id, product_id))
+    #     self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+    # def test_server_error(self):
+    #     """ Test error handlers internal server error """
+    #     resp = self.app.put("/shopcarts?")
+    #     self.assertEqual(resp.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+    def test_method_not_allowed(self):
+            """ Test error handlers method not allowed """
+            resp = self.app.put("/shopcarts?")
+            self.assertEqual(resp.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+    def test_unsupported_media(self):
+        """ Test error handlers unsupported media type """
+        shopcart_id = 123
+        resp = self.app.post("/shopcarts/{}".format(shopcart_id))
+        self.assertEqual(resp.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)


### PR DESCRIPTION
Renamed the `shopcart-id` param and `product-id` param to `shopcart_id` and `product_id` as per professor's suggestion to follow app variables.

Coverage dropped to 90% with the error handlers activated. Added two handler tests for unsupported media, and method not allowed. Could not figure out a successful test for internal server error and bad request.